### PR TITLE
Fixed the response parameter in the _upsertProfile function

### DIFF
--- a/oesdk/demand_profiles.py
+++ b/oesdk/demand_profiles.py
@@ -39,7 +39,7 @@ class DemandApi():
             logging.warning(
                 "The HTTP response about the Energy Manager mode is: '{}'".format(
                     em_mode_http_response.content))
-            response.raise_for_status()
+            em_mode_http_response.raise_for_status()
             raise ValueError(
                 "The HTTP response code was not {}".format(
                     requests.codes.NO_CONTENT))


### PR DESCRIPTION
The parameter which returns the response from the http request was set to an unknown variable, so modify the name of the parameter within the error messages to align with the specified variable for the response so the code runs.